### PR TITLE
행렬 매핑 정정 + 임시 컨텍스트 수거 + 패딩 안전화 + 공통 매크로 제어

### DIFF
--- a/ggml/src/ggml-gemmini/CMakeLists.txt
+++ b/ggml/src/ggml-gemmini/CMakeLists.txt
@@ -19,6 +19,14 @@ target_compile_options(ggml-gemmini PRIVATE
   -ffast-math
 )
 
+target_compile_definitions(ggml-gemmini PRIVATE
+  DEBUG=1         # ggml-gemmini-util.h에서 쓰는 DEBUG 매크로
+  TEST=0          # 필요 시
+  PRINT_TILE=0    # 필요 시
+  OPTION=CPU      # OS/WS/CPU
+)
+
+
 target_include_directories(ggml-gemmini PRIVATE
   ${RISCV_TOOL_PATH}/sysroot/include
   ${GEMMINI_SW_PATH}/gemmini-rocc-tests

--- a/ggml/src/ggml-gemmini/ggml-gemmini-tensor.cpp
+++ b/ggml/src/ggml-gemmini/ggml-gemmini-tensor.cpp
@@ -1,5 +1,4 @@
 // ggml-gemmini-tensor.cpp
-#define DEBUG 1
 
 #include "ggml-gemmini-tensor.h"
 

--- a/ggml/src/ggml-gemmini/ggml-gemmini.cpp
+++ b/ggml/src/ggml-gemmini/ggml-gemmini.cpp
@@ -13,6 +13,8 @@ static void ggml_backend_gemmini_mul_mat(
                                          struct ggml_tensor *dst, // FP32 output (I×J)
                                          struct ggml_tensor *bias) // optional FP32 bias (->int32)
 {
+    size_t mu0 = ggml_used_mem(ctx->tmp_ctx);
+
     #if TEST
     {
         // PATH로 'OS', 'WS', 'CPU' 제어
@@ -40,6 +42,11 @@ static void ggml_backend_gemmini_mul_mat(
     std::optional<ggml_gemmini_tensor<int32_t>> tD;
     if (bias)
         tD.emplace(ctx->tmp_ctx, bias, ".i32");
+
+    // 메모리 사용량 측정
+    size_t mu1 = ggml_used_mem(ctx->tmp_ctx);
+    size_t mul_hdr = (mu1 >= mu0) ? (mu1 - mu0) : mu1;
+    DBG("[Gemmini] MUL_MAT header used = %zu bytes\n", mul_hdr);
 
     const size_t I = tC.get_rows(); // I = A.ne[1], K = A.ne[0]
     const size_t J = tC.get_cols(); // K = B.ne[0], J = B.ne[1] (transpose)
@@ -130,13 +137,18 @@ static enum ggml_status ggml_backend_gemmini_graph_compute(ggml_backend_t backen
     }
 
     struct ggml_init_params ip = {
-        /* .mem_size   = */ 320ull * 1024 * 1024, // 320MiB
+        /* .mem_size   = */ 8ull * 1024 * 1024, // 320MiB
         /* .mem_buffer = */ NULL,
         /* .no_alloc   = */ true, // 헤더만
     };
 
     ctx->tmp_ctx = ggml_init(ip);
     GGML_ASSERT(ctx->tmp_ctx);
+
+    // 메모리 사용량 측정
+    DBG("[Gemmini] sizeof(ggml_tensor) = %zu\n", sizeof(struct ggml_tensor));
+    size_t used0 = ggml_used_mem(ctx->tmp_ctx);
+    DBG("[Gemmini] tmp_ctx used(start) = %zu bytes\n", used0);
 
     for (int i = 0; i < cgraph->n_nodes; i++)
     {
@@ -168,6 +180,10 @@ static enum ggml_status ggml_backend_gemmini_graph_compute(ggml_backend_t backen
             GGML_ABORT("%s: unsupported op %s\n", __func__, ggml_op_desc(node));
         }
     }
+    size_t used1 = ggml_used_mem(ctx->tmp_ctx);
+    size_t hdr_bytes = (used1 >= used0) ? (used1 - used0) : used1; // 방어적
+    DBG("[Gemmini] tmp_ctx header used(total) = %zu bytes (%.2f MiB)\n", hdr_bytes, hdr_bytes / (1024.0 * 1024.0));
+
     ctx->bias_map.clear();
     // tmp_ctx 해제
     ggml_free(ctx->tmp_ctx);

--- a/ggml/src/ggml-gemmini/ggml-gemmini.cpp
+++ b/ggml/src/ggml-gemmini/ggml-gemmini.cpp
@@ -1,6 +1,4 @@
-#define DEBUG 1
-#define TEST 0
-#define OPTION CPU // OS, WS, CPU
+// ggml-gemmini.cpp
 
 #include "ggml-gemmini-tensor.h"
 #include "include/gemmini.h"

--- a/ggml/src/ggml-gemmini/ggml-gemmini.cpp
+++ b/ggml/src/ggml-gemmini/ggml-gemmini.cpp
@@ -110,7 +110,7 @@ static void ggml_backend_gemmini_mul_mat(
                       false, // transpose_A
                       false, // transpose_B
                       false, false,
-                      0, CPU);
+                      0, OPTION);
     /* _______________________________________ */
 
     /* _____________ 6. Gemmini 연산 결과를 원본 출력 텐서로 반영 _____________ */

--- a/ggml/src/ggml-gemmini/ggml-gemmini.cpp
+++ b/ggml/src/ggml-gemmini/ggml-gemmini.cpp
@@ -36,9 +36,9 @@ static void ggml_backend_gemmini_mul_mat(
     DBG("\nsrc0 shape:\n ne = [%llu, %llu, %llu, %llu]\n", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
     DBG("\nsrc1 shape:\n ne = [%llu, %llu, %llu, %llu]\n", src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3]);
 
-    ggml_gemmini_tensor<int8_t> tA(ctx->tmp_ctx, src0, ".i8");
-    ggml_gemmini_tensor<int8_t> tB(ctx->tmp_ctx, src1, ".i8", false, true);
-    ggml_gemmini_tensor<int8_t> tC(ctx->tmp_ctx, dst, ".i8", true);
+    ggml_gemmini_tensor<int8_t> tA(ctx->tmp_ctx, src1, ".i8"); // IxK (1xK)
+    ggml_gemmini_tensor<int8_t> tB(ctx->tmp_ctx, src0, ".i8", false, true); // KxJ
+    ggml_gemmini_tensor<int8_t> tC(ctx->tmp_ctx, dst, ".i8", true); // IxJ (1xJ)
     std::optional<ggml_gemmini_tensor<int32_t>> tD;
     if (bias)
         tD.emplace(ctx->tmp_ctx, bias, ".i32");
@@ -137,7 +137,7 @@ static enum ggml_status ggml_backend_gemmini_graph_compute(ggml_backend_t backen
     }
 
     struct ggml_init_params ip = {
-        /* .mem_size   = */ 8ull * 1024 * 1024, // 320MiB
+        /* .mem_size   = */ 8ull * 1024 * 1024, // 8MiB
         /* .mem_buffer = */ NULL,
         /* .no_alloc   = */ true, // 헤더만
     };

--- a/ggml/src/ggml-gemmini/ggml-gemmini.cpp
+++ b/ggml/src/ggml-gemmini/ggml-gemmini.cpp
@@ -151,7 +151,7 @@ static enum ggml_status ggml_backend_gemmini_graph_compute(ggml_backend_t backen
                 bias = it->second;
 
             ggml_backend_gemmini_mul_mat(ctx, node, bias);
-
+            break;
         }
         case GGML_OP_OUT_PROD:
             // ggml_backend_gemmini_out_prod(ctx, node);
@@ -169,6 +169,9 @@ static enum ggml_status ggml_backend_gemmini_graph_compute(ggml_backend_t backen
         }
     }
     ctx->bias_map.clear();
+    // tmp_ctx 해제
+    ggml_free(ctx->tmp_ctx);
+    ctx->tmp_ctx = nullptr;
 
     return GGML_STATUS_SUCCESS;
 

--- a/ggml/src/ggml-gemmini/ggml-gemmini.cpp
+++ b/ggml/src/ggml-gemmini/ggml-gemmini.cpp
@@ -1,5 +1,6 @@
 #define DEBUG 1
 #define TEST 0
+#define OPTION CPU // OS, WS, CPU
 
 #include "ggml-gemmini-tensor.h"
 #include "include/gemmini.h"
@@ -13,65 +14,89 @@ static void ggml_backend_gemmini_mul_mat(
                                          struct ggml_tensor *dst, // FP32 output (I×J)
                                          struct ggml_tensor *bias) // optional FP32 bias (->int32)
 {
+/* ______________ Debug: 헤더 사용량 측정 _______________ */
+#if DEBUG
     size_t mu0 = ggml_used_mem(ctx->tmp_ctx);
+#endif
+/* _____________________________________________________ */
 
-    #if TEST
+/* ________________ Test: 테스트 호출용 ___________________ */
+#if TEST
     {
-        // PATH로 'OS', 'WS', 'CPU' 제어
-        ggml_backend_gemmini_mul_mat_test(/* I */2, 
-                                          /* J */3, 
-                                          /* K */2, 
-                                          /* PATH */ CPU);
+        // OPTION에 따라 동작
+        ggml_backend_gemmini_mul_mat_test(/* I */ 2,
+                                          /* J */ 3,
+                                          /* K */ 2);
         return;
     }
-    #endif
+#endif
+    /* ______________________________________________________ */
 
     DBG("[Gemmini] mul_mat call\n");
 
-    // 0. 원본 FP32 입력 텐서
-    const auto *src0 = dst->src[0];         // A:  I × K
-    const auto *src1 = dst->src[1];         // B:  K × J (But transpose되어 메모리상 J x K)
+    /* ____________________________________ 0. 원본 FP32 입력 텐서 ____________________________________________ */
+    const auto *src0 = dst->src[0]; // src0: weight (J × K) -> 전치하여 K x J로 사용 (B)
+    const auto *src1 = dst->src[1]; // src1: activation (K x J) -> 전치 없음 (A)
 
     DBG("\ndst shape:\n ne = [%llu, %llu, %llu, %llu]\n", dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
     DBG("\nsrc0 shape:\n ne = [%llu, %llu, %llu, %llu]\n", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
     DBG("\nsrc1 shape:\n ne = [%llu, %llu, %llu, %llu]\n", src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3]);
+    /* _______________________________________________________________________________________________________ */
 
-    ggml_gemmini_tensor<int8_t> tA(ctx->tmp_ctx, src1, ".i8"); // IxK (1xK)
-    ggml_gemmini_tensor<int8_t> tB(ctx->tmp_ctx, src0, ".i8", false, true); // KxJ
-    ggml_gemmini_tensor<int8_t> tC(ctx->tmp_ctx, dst, ".i8", true); // IxJ (1xJ)
-    std::optional<ggml_gemmini_tensor<int32_t>> tD;
+    /* _____________________________ 1. Gemmini용 텐서 생성 _____________________________ */
+    ggml_gemmini_tensor<int8_t> tA(ctx->tmp_ctx, src1, ".i8");              // IxK (1xK)
+    ggml_gemmini_tensor<int8_t> tB(ctx->tmp_ctx, src0, ".i8", false, true); // KxJ, 전치
+    ggml_gemmini_tensor<int8_t> tC(ctx->tmp_ctx, dst, ".i8", true);         // IxJ (1xJ)
+    std::optional<ggml_gemmini_tensor<int32_t>> tD;                         // optional로 임시 생성
     if (bias)
         tD.emplace(ctx->tmp_ctx, bias, ".i32");
 
-    // 메모리 사용량 측정
+/* ____________________ Debug: 헤더 사용량 측정 ___________________ */
+#if DEBUG
+
     size_t mu1 = ggml_used_mem(ctx->tmp_ctx);
     size_t mul_hdr = (mu1 >= mu0) ? (mu1 - mu0) : mu1;
     DBG("[Gemmini] MUL_MAT header used = %zu bytes\n", mul_hdr);
+    
+#endif
+/* ______________________________________________________________ */
 
+    /* ___________________ Guard: runtime dimension _____________________ */
+    GGML_ASSERT(tA.get_rows() == dst->ne[1]);    // I == dst rows (보통 1)
+    GGML_ASSERT(tA.get_cols() == tB.get_rows()); // K == K
+    GGML_ASSERT(tC.get_rows() == tA.get_rows()); // I == I
+    GGML_ASSERT(tC.get_cols() == tB.get_cols()); // J(padded) == J(padded)
+    GGML_ASSERT(dst->ne[0] <= tC.get_cols());    // 논리 J <= 패딩 J
+    /* __________________________________________________________________ */
+
+    /* _______________________ 2. Gemmini용 dimension _____________________ */
     const size_t I = tC.get_rows(); // I = A.ne[1], K = A.ne[0]
     const size_t J = tC.get_cols(); // K = B.ne[0], J = B.ne[1] (transpose)
     const size_t K = tA.get_cols();
     DBG("I=%zu, J=%zu, K=%zu\n", I, J, K);
+    /* ____________________________________________________________________ */
 
-    // stride
+    /* _____ 3. Gemmini용 stride _____ */
     const size_t sA = tA.get_stride();
     const size_t sB = tB.get_stride();
     const size_t sC = tC.get_stride();
     GGML_ASSERT(sA % 16 == 0);
     GGML_ASSERT(sB % 16 == 0);
     GGML_ASSERT(sC % 16 == 0);
+    /* _______________________________ */
 
-    // bias tensor
-    std::vector<int32_t> zero_bias(tC.get_cols(), 0); 
+    /* ______________________________ 4. bias 텐서 처리 _________________________________ */
+    std::vector<int32_t> zero_bias(tC.get_cols(), 0);
 
     const int32_t *bias_data = tD ? static_cast<int32_t *>(tD->get()) : zero_bias.data();
     const size_t sD = tD ? tD->get_stride() : 0;
     const bool repeating = tD ? tD->get_rows() == 1 : true;
 
     DBG("calling tiled_matmul_auto: ptrA=%p ptrB=%p ptrD=%p ptrC=%p\n",
-           (void*)tA.get(), (void*)tB.get(), (void*)bias_data, (void*)tC.get());
+        (void *)tA.get(), (void *)tB.get(), (void *)bias_data, (void *)tC.get());
+    /* _________________________________________________________________________________ */
 
-    // 5. Gemmini 호출
+    /* __ 5. Gemmini tiled_matmul_auto 호출 __ */
     tiled_matmul_auto(I, J, K,
                       (elem_t *)tA.get(),
                       (elem_t *)tB.get(),
@@ -86,9 +111,11 @@ static void ggml_backend_gemmini_mul_mat(
                       false, // transpose_B
                       false, false,
                       0, CPU);
+    /* _______________________________________ */
 
-    // 6. 결과를 tC(int8) -> dst(float)로 반영
+    /* _____________ 6. Gemmini 연산 결과를 원본 출력 텐서로 반영 _____________ */
     const size_t nb1_out = dst->nb[1]; // 출력 텐서 행 stride (bytes)
+    const size_t J_log = dst->ne[0];   // 실제 논리 열 수
 
     int8_t *c_i8 = static_cast<int8_t *>(tC.get());
     uint8_t *out_base = static_cast<uint8_t *>(dst->data);
@@ -99,12 +126,12 @@ static void ggml_backend_gemmini_mul_mat(
         float *row_out = reinterpret_cast<float *>(out_base + r * nb1_out);
 
         // 스케일/클리핑 없이 그대로 float 캐스팅
-        for (size_t c = 0; c < J; ++c)
+        for (size_t c = 0; c < J_log; ++c)
             row_out[c] = static_cast<float>(row_c[c]);
-            // 패딩 영역(row_c[J..sC-1])은 무시
+        // 패딩 영역(row_c[J..sC-1])은 무시
     }
+    /* ____________________________________________________________________ */
 }
-
 
 static void ggml_backend_gemmini_out_prod(ggml_backend_gemmini_context * ctx, struct ggml_tensor * dst) {
     GGML_UNUSED(ctx);
@@ -145,10 +172,15 @@ static enum ggml_status ggml_backend_gemmini_graph_compute(ggml_backend_t backen
     ctx->tmp_ctx = ggml_init(ip);
     GGML_ASSERT(ctx->tmp_ctx);
 
-    // 메모리 사용량 측정
+/* __________________________ Debug: 헤더 사용량 측정 ____________________________ */
+#if DEBUG
+
     DBG("[Gemmini] sizeof(ggml_tensor) = %zu\n", sizeof(struct ggml_tensor));
     size_t used0 = ggml_used_mem(ctx->tmp_ctx);
     DBG("[Gemmini] tmp_ctx used(start) = %zu bytes\n", used0);
+
+#endif
+/* _____________________________________________________________________________ */
 
     for (int i = 0; i < cgraph->n_nodes; i++)
     {
@@ -180,18 +212,24 @@ static enum ggml_status ggml_backend_gemmini_graph_compute(ggml_backend_t backen
             GGML_ABORT("%s: unsupported op %s\n", __func__, ggml_op_desc(node));
         }
     }
+
+/* _______________________________________ Debug: 헤더 사용량 측정 ________________________________________________ */
+#if DEBUG
+
     size_t used1 = ggml_used_mem(ctx->tmp_ctx);
     size_t hdr_bytes = (used1 >= used0) ? (used1 - used0) : used1; // 방어적
     DBG("[Gemmini] tmp_ctx header used(total) = %zu bytes (%.2f MiB)\n", hdr_bytes, hdr_bytes / (1024.0 * 1024.0));
+
+#endif
+/* _______________________________________________________________________________________________________________ */
 
     ctx->bias_map.clear();
     // tmp_ctx 해제
     ggml_free(ctx->tmp_ctx);
     ctx->tmp_ctx = nullptr;
 
-    return GGML_STATUS_SUCCESS;
-
     GGML_UNUSED(backend);
+    return GGML_STATUS_SUCCESS;
 }
 
 static struct ggml_backend_i gemmini_backend_i = {

--- a/ggml/src/ggml-gemmini/ggml-gemmini.cpp
+++ b/ggml/src/ggml-gemmini/ggml-gemmini.cpp
@@ -129,16 +129,14 @@ static enum ggml_status ggml_backend_gemmini_graph_compute(ggml_backend_t backen
             ctx->bias_map[node->src[0]] = node->src[1];
     }
 
+    struct ggml_init_params ip = {
+        /* .mem_size   = */ 320ull * 1024 * 1024, // 320MiB
+        /* .mem_buffer = */ NULL,
+        /* .no_alloc   = */ true, // 헤더만
+    };
 
-        struct ggml_init_params ip = {
-            /* .mem_size   = */ 320ull * 1024 * 1024, // 320MiB
-            /* .mem_buffer = */ NULL,
-            /* .no_alloc   = */ true, // 헤더만 
-        };
-
-        ctx->tmp_ctx = ggml_init(ip);
-        GGML_ASSERT(ctx->tmp_ctx);
-
+    ctx->tmp_ctx = ggml_init(ip);
+    GGML_ASSERT(ctx->tmp_ctx);
 
     for (int i = 0; i < cgraph->n_nodes; i++)
     {

--- a/ggml/src/ggml-gemmini/test/ggml-gemmini-test.h
+++ b/ggml/src/ggml-gemmini/test/ggml-gemmini-test.h
@@ -2,6 +2,10 @@
 #ifndef __GGML_GEMMINI_TEST_H__
 #define __GGML_GEMMINI_TEST_H__
 
+#ifndef OPTION
+#define OPTION CPU
+#endif
+
 #include "include/gemmini.h"
 #include <cstdio>
 #include <type_traits>
@@ -37,7 +41,7 @@ static inline int8_t sat_i8(int x) {
     return x > 127 ? 127 : (x < -128 ? -128 : (int8_t)x);
 }
 
-static void ggml_backend_gemmini_mul_mat_test(const int i, const int j, const int k, tiled_matmul_type_t PATH) {
+static void ggml_backend_gemmini_mul_mat_test(const int i, const int j, const int k) {
     GGML_ASSERT(i > 0 && j > 0 && k > 0);
 
     DBG0("\n[Gemmini] mul_mat test called");
@@ -119,7 +123,7 @@ static void ggml_backend_gemmini_mul_mat_test(const int i, const int j, const in
                       false, // transpose_A
                       false, // transpose_B
                       false, false,
-                      0, PATH);
+                      0, OPTION);
 
     dump_matrix("C (result from gemmini)", C, I, J, sC);
 


### PR DESCRIPTION
# 변경 사항
1. 행렬 매핑 정정: `A = src1(1×K)`, `B = transpose(src0)(K×J)`로 고정.
2. 중간 버퍼/컨텍스트 관리: 그래프 단위 임시 컨텍스트(`tmp_ctx`)를 8 MiB 헤더 전용으로 생성 후 `ggml_free()`.
3. 패딩 안전화: `tC(i8)` &rarr; `dst(f32)` 복사 시 논리 길이(`dst->ne[0`])까지만 복사.
4. 헤더 메모리 측정 추가: `ggml_used_mem()`으로 그래프/연산 단위 헤더 사용량 로깅. (`DEBUG`로 제어)
5. 안전 가드: 런타임 차원 검증 GGML_ASSERT 추가 및 switch 문 `ggml_backend_gemmini_mul_mat` 호출 시 `break;` 누락 추가.
6. 매크로 제어 통일: CMake의 target_compile_definitions로 번역 단위 전체에서 on/off.
- DEBUG: DBG 매크로 제어 (1: on, 0: off)
- TEST: test용 함수 제어 (1: on, 0: off)
- PRINT_TILE: gemmini의 `tiled_matmul_auto()` 내부 디버그 매크로 제어 (1: on, 0: off)
- OPTION: `tiled_matmul_auto()` 실행 옵션 설정 (OS, WS, CPU)

# 헤더 메모리 (ex.)
- 헤더 사용량(그래프): tmp_ctx header used(total) = 1104 bytes
- FFN down: I=1, J=768, K=3072
- Logits: I=1, J=50272(pad), K=768
- tB(logits) 버퍼: buf_bytes ≈ 38,608,896 (≈36.8 MB, 패딩 포함)
&rarr; 헤더 사용량은 ~1.1 KiB/호출 수준이며, 그래프 종료 시 컨텍스트를 해제하여 누수 없음.

# 성능/정확성 메모
- A/B 매핑 정정 후 연산/캐스팅/복사량 증가로 실행 시간이 길어질 것으로 추정
- Q8_0 미구현으로 아직 정확도가 많이 낮아 결과 토큰 출력 x